### PR TITLE
Fix test 19

### DIFF
--- a/t/19-gnuplot-bin.t
+++ b/t/19-gnuplot-bin.t
@@ -36,9 +36,15 @@ my class Capture {
 # 2. A user-supplied :gnuplot path is accepted.
 {
     my $fake = make-fake-gnuplot;
+    my $gnu;
     lives-ok {
-        my $gnu = Chart::Gnuplot.new(:terminal("png"), :filename("sample.png"), :gnuplot($fake));
+        $gnu = Chart::Gnuplot.new(:terminal("png"), :filename("sample.png"), :gnuplot($fake));
     }, "Chart::Gnuplot.new should accept a user-supplied :gnuplot path.";
+    # dispose awaits the subprocess promise, guaranteeing the binary has been
+    # exec'd before we remove it. Removing it earlier races the async spawn and
+    # makes exec fail with "no such file or directory" (notably on macOS, where
+    # $*TMPDIR lives under /var/folders).
+    $gnu.dispose;
     $fake.IO.unlink;
 }
 
@@ -52,6 +58,7 @@ my class Capture {
     sleep 1;
     ok $cap.buf.contains("FAKEGNUPLOT:set xrange [0:1]"),
         "The user-supplied :gnuplot binary should be the one that receives commands.";
+    $gnu.dispose;
     $fake.IO.unlink;
 }
 


### PR DESCRIPTION
Fix flaky t/19 spawn race on macOS

t/19-gnuplot-bin.t removed the fake gnuplot script with $fake.IO.unlink immediately after constructing the chart. Since Proc::Async starts the subprocess asynchronously, the unlink could win the race against the actual exec. On macOS (where $*TMPDIR lives under /var/folders/...) this surfaced as:


Failed to spawn process .../fake-gnuplot-...: no such file or directory
and, because the rejected start promise was never awaited, it leaked out as an Unhandled exception in code scheduled on thread N that bled into other tests' output.

Fix: call $gnu.dispose before unlinking. dispose awaits the subprocess promise, so the binary is guaranteed to have been exec'd before the file is removed. Test-only change; the library itself is unaffected in normal usage with a real gnuplot.