### PR TITLE
Fix multiplot state handling and add scoped block form

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,15 +620,37 @@ Places an arrow on a plot.
 
 Defined as:
 
-    multi method arrow(
-          :$tag, :$from, :$rto, Bool :$head, TrueOnly :$backhead, TrueOnly :$heads,
-          :$head-length, :$head-angle, :$back-angle,
-          Bool :$filled, TrueOnly :$empty, TrueOnly :$border,
-          TrueOnly :$front, TrueOnly :$back,
-          :ls(:$linestyle), :lt(:$linetype), :lw(:$linewidth), :lc(:$linecolor), :dt(:$dashtype), :&writer? = -> $msg { self.command: $msg }
+    multi method multiplot(
+          :$title, :$font-name, :$font-size, Bool :$enhanced, :@layout,
+          :$rowsfirst, :$columnsfirst, :$downwards, :$upwards,
+          :$scale, :$offset, :$margins, :$spacing,
+          :&writer = -> $msg { self.command: $msg }
+    )
+
+    multi method multiplot(
+          &body,
+          :$title, :$font-name, :$font-size, Bool :$enhanced, :@layout,
+          :$rowsfirst, :$columnsfirst, :$downwards, :$upwards,
+          :$scale, :$offset, :$margins, :$spacing,
+          :&writer = -> $msg { self.command: $msg }
     )
 
 Places gnuplot in the multiplot mode, in which several plots are placed next to each other on the same page or screen window.
+Each subsequent `plot` or `splot` call starts a new panel.
+When `&body` is provided, multiplot mode is ended automatically after the block, including when the block throws an exception.
+
+    $gnu.multiplot(:layout([1, 2]), {
+        $gnu.plot(:function("sin(x)"));
+        $gnu.plot(:function("cos(x)"));
+    });
+
+### end-multiplot
+
+Defined as:
+
+    method end-multiplot(:&writer = -> $msg { self.command: $msg })
+
+Leaves multiplot mode and resets plotting state so that the next `plot` or `splot` starts a new chart.
 
 ### command
 
@@ -809,4 +831,3 @@ COPYRIGHT AND LICENSE
 Copyright 2017 titsuki
 
 This library is free software; you can redistribute it and/or modify it under the GNU General Public License version 3.0.
-

--- a/lib/Chart/Gnuplot.pm6
+++ b/lib/Chart/Gnuplot.pm6
@@ -21,6 +21,7 @@ has Bool $.persist;
 has $.debug;
 has %.options;
 has Int $!num-plot;
+has Bool $!in-multiplot;
 has $!promise;
 has $!msg-channel;
 has $!msg-supply;
@@ -61,6 +62,7 @@ submethod BUILD(:$terminal!, Str :$filename, Str :$gnuplot?, :$!persist = True, 
     }
     $!promise = $!gnuplot.start;
     $!num-plot = 0;
+    $!in-multiplot = False;
 
     $!arrow = Chart::Gnuplot::Arrow.new(:&!writer);
     $!border = Chart::Gnuplot::Border.new(:&!writer);
@@ -129,13 +131,12 @@ multi method plot(:$title, :$ignore, :@range, :@vertices!, :$smooth,
     @args.push("nosurface") if $surface.defined and $surface == False;
     @args.push("palette") if $palette.defined;
 
-    $!terminal.writer(&writer).set;
-    $!output.writer(&writer).set;
+    unless $!in-multiplot {
+        $!terminal.writer(&writer).set;
+        $!output.writer(&writer).set;
+    }
 
-    my $cmd = do given $!num-plot {
-        when * > 0 { "replot" }
-        default { "plot" }
-    };
+    my $cmd = ($!in-multiplot || $!num-plot == 0) ?? "plot" !! "replot";
     &writer(sprintf("%s %s",$cmd, @args.grep(* ne "").join(" ")));
     $!num-plot++;
 }
@@ -175,13 +176,12 @@ multi method plot(:$title, :$ignore, :@range, :$function!, :$smooth,
     @args.push("nosurface") if $surface.defined and $surface == False;
     @args.push("palette") if $palette.defined;
 
-    $!terminal.writer(&writer).set;
-    $!output.writer(&writer).set;
+    unless $!in-multiplot {
+        $!terminal.writer(&writer).set;
+        $!output.writer(&writer).set;
+    }
 
-    my $cmd = do given $!num-plot {
-        when * > 0 { "replot" }
-        default { "plot" }
-    };
+    my $cmd = ($!in-multiplot || $!num-plot == 0) ?? "plot" !! "replot";
 
     &writer(sprintf("%s %s", $cmd, @args.grep(* ne "").join(" ")));
     $!num-plot++;
@@ -234,13 +234,12 @@ multi method splot(:@range,
     @args.push("nosurface") if $surface.defined and $surface == False;
     @args.push("palette") if $palette.defined;
 
-    $!terminal.writer(&writer).set;
-    $!output.writer(&writer).set;
+    unless $!in-multiplot {
+        $!terminal.writer(&writer).set;
+        $!output.writer(&writer).set;
+    }
 
-    my $cmd = do given $!num-plot {
-        when * > 0 { "replot" }
-        default { "splot" }
-    };
+    my $cmd = ($!in-multiplot || $!num-plot == 0) ?? "splot" !! "replot";
     &writer(sprintf("%s %s", $cmd, @args.grep(* ne "").join(" ")));
     $!num-plot++;
 }
@@ -279,20 +278,19 @@ multi method splot(:@range,
     @args.push("nosurface") if $surface.defined and $surface == False;
     @args.push("palette") if $palette.defined;
 
-    $!terminal.writer(&writer).set;
-    $!output.writer(&writer).set;
+    unless $!in-multiplot {
+        $!terminal.writer(&writer).set;
+        $!output.writer(&writer).set;
+    }
 
-    my $cmd = do given $!num-plot {
-        when * > 0 { "replot" }
-        default { "splot" }
-    };
+    my $cmd = ($!in-multiplot || $!num-plot == 0) ?? "splot" !! "replot";
     &writer(sprintf("%s %s", $cmd, @args.grep(* ne "").join(" ")));
     $!num-plot++;
 }
 
-method multiplot(:$title, :$font-name, :$font-size, Bool :$enhanced, :@layout, :$rowsfirst, :$columnsfirst,
-                 :$downwards, :$upwards, :$scale, :$offset, :$margins,
-                 :$spacing, :&writer = -> $msg { self.command: $msg }) {
+multi method multiplot(:$title, :$font-name, :$font-size, Bool :$enhanced, :@layout, :$rowsfirst, :$columnsfirst,
+                       :$downwards, :$upwards, :$scale, :$offset, :$margins,
+                       :$spacing, :&writer = -> $msg { self.command: $msg }) {
     my @args;
 
     @args.push(sprintf("title \"%s\"", $title)) if $title.defined;
@@ -308,7 +306,27 @@ method multiplot(:$title, :$font-name, :$font-size, Bool :$enhanced, :@layout, :
     @args.push("margins " ~ $margins.join(",")) if $margins.elems == 4;
     @args.push("spacing " ~ $spacing.join(",")) if $spacing.defined;
 
-    &writer(sprintf("set multiplot %s", @args.grep(* ne "").join(" ")));
+    my $options = @args.grep(* ne "").join(" ");
+    $!terminal.writer(&writer).set;
+    $!output.writer(&writer).set;
+    &writer($options ?? "set multiplot $options" !! "set multiplot");
+    $!in-multiplot = True;
+    $!num-plot = 0;
+}
+
+multi method multiplot(&body, :$title, :$font-name, :$font-size, Bool :$enhanced, :@layout, :$rowsfirst, :$columnsfirst,
+                       :$downwards, :$upwards, :$scale, :$offset, :$margins,
+                       :$spacing, :&writer = -> $msg { self.command: $msg }) {
+    self.multiplot(:$title, :$font-name, :$font-size, :$enhanced, :@layout, :$rowsfirst, :$columnsfirst,
+                   :$downwards, :$upwards, :$scale, :$offset, :$margins, :$spacing, :&writer);
+    LEAVE self.end-multiplot(:&writer);
+    body();
+}
+
+method end-multiplot(:&writer = -> $msg { self.command: $msg }) {
+    &writer("unset multiplot");
+    $!in-multiplot = False;
+    $!num-plot = 0;
 }
 
 method dispose {
@@ -938,15 +956,32 @@ Places an arrow on a plot.
 
 Defined as:
 
-        multi method arrow(
-              :$tag, :$from, :$rto, Bool :$head, TrueOnly :$backhead, TrueOnly :$heads,
-              :$head-length, :$head-angle, :$back-angle,
-              Bool :$filled, TrueOnly :$empty, TrueOnly :$border,
-              TrueOnly :$front, TrueOnly :$back,
-              :ls(:$linestyle), :lt(:$linetype), :lw(:$linewidth), :lc(:$linecolor), :dt(:$dashtype), :&writer? = -> $msg { self.command: $msg }
+        multi method multiplot(
+              :$title, :$font-name, :$font-size, Bool :$enhanced, :@layout,
+              :$rowsfirst, :$columnsfirst, :$downwards, :$upwards,
+              :$scale, :$offset, :$margins, :$spacing,
+              :&writer = -> $msg { self.command: $msg }
+        )
+
+        multi method multiplot(
+              &body,
+              :$title, :$font-name, :$font-size, Bool :$enhanced, :@layout,
+              :$rowsfirst, :$columnsfirst, :$downwards, :$upwards,
+              :$scale, :$offset, :$margins, :$spacing,
+              :&writer = -> $msg { self.command: $msg }
         )
 
 Places gnuplot in the multiplot mode, in which several plots are placed next to each other on the same page or screen window.
+Each subsequent C<plot> or C<splot> call starts a new panel.
+When C<&body> is provided, multiplot mode is ended automatically after the block, including when the block throws an exception.
+
+=head3 end-multiplot
+
+Defined as:
+
+        method end-multiplot(:&writer = -> $msg { self.command: $msg })
+
+Leaves multiplot mode and resets plotting state so that the next C<plot> or C<splot> starts a new chart.
 
 =head3 command
 

--- a/t/18-multiplot.t
+++ b/t/18-multiplot.t
@@ -23,7 +23,7 @@ sub comp(@lhs, @rhs) returns Bool {
     my @actual;
     $gnu.multiplot(:title("Perl6 is fun"), :font-name("Helvetica"), :writer(-> $msg { @actual.push($msg); }));
     $gnu.dispose;
-    my @expected = 'set multiplot title "Perl6 is fun" font "Helvetica"';
+    my @expected = 'set terminal svg', 'set output "actual.svg"', 'set multiplot title "Perl6 is fun" font "Helvetica"';
     is @actual, @expected, 'Given :title, :font-name as arguments, then Chart::Gnuplot.multiplot should set these properties.';
 }
 
@@ -32,7 +32,7 @@ sub comp(@lhs, @rhs) returns Bool {
     my @actual;
     $gnu.multiplot(:title("Perl6 is fun"), :font-size(10), :writer(-> $msg { @actual.push($msg); }));
     $gnu.dispose;
-    my @expected = 'set multiplot title "Perl6 is fun" font ",10"';
+    my @expected = 'set terminal svg', 'set output "actual.svg"', 'set multiplot title "Perl6 is fun" font ",10"';
     is @actual, @expected, 'Given :title, :font-size as arguments, then Chart::Gnuplot.multiplot should set these properties.';
 }
 
@@ -41,7 +41,7 @@ sub comp(@lhs, @rhs) returns Bool {
     my @actual;
     $gnu.multiplot(:title("Perl6 is fun"), :layout([2,2]), :writer(-> $msg { @actual.push($msg); }));
     $gnu.dispose;
-    my @expected = 'set multiplot title "Perl6 is fun" layout 2,2';
+    my @expected = 'set terminal svg', 'set output "actual.svg"', 'set multiplot title "Perl6 is fun" layout 2,2';
     is @actual, @expected, 'Given :title, :layout as arguments, then Chart::Gnuplot.multiplot should set these properties.';
 }
 
@@ -50,8 +50,68 @@ sub comp(@lhs, @rhs) returns Bool {
     my @actual;
     $gnu.multiplot(:title("Perl6 is fun"), :offset("graph" => 0), :writer(-> $msg { @actual.push($msg); }));
     $gnu.dispose;
-    my @expected = 'set multiplot title "Perl6 is fun" offset graph 0';
+    my @expected = 'set terminal svg', 'set output "actual.svg"', 'set multiplot title "Perl6 is fun" offset graph 0';
     is @actual, @expected, 'Given :title, :offset as arguments, then Chart::Gnuplot.multiplot should set these properties.';
+}
+
+{
+    my $gnu = Chart::Gnuplot.new(:terminal("svg"), :filename("actual.svg"));
+    my @actual;
+    my &writer = -> $msg { @actual.push($msg) };
+
+    $gnu.multiplot(:layout([1, 2]), :&writer);
+    $gnu.plot(:function("sin(x)"), :&writer);
+    $gnu.splot(:function("x*y"), :&writer);
+    $gnu.end-multiplot(:&writer);
+    $gnu.plot(:function("tan(x)"), :&writer);
+    $gnu.plot(:function("x"), :&writer);
+    $gnu.dispose;
+
+    my @plot-commands = @actual.grep({ .starts-with("plot ") || .starts-with("replot ") || .starts-with("splot ") });
+    my @expected = 'plot sin(x)', 'splot x*y', 'plot tan(x)', 'replot x';
+    is @plot-commands, @expected, 'Each multiplot panel uses plot, and ending multiplot resets plotting state.';
+    ok @actual.grep(* eq 'unset multiplot'), 'end-multiplot leaves multiplot mode.';
+    is @actual[0..4], ['set terminal svg', 'set output "actual.svg"', 'set multiplot layout 1,2', 'plot sin(x)', 'splot x*y'],
+        'The terminal and output are configured once before multiplot starts.';
+}
+
+{
+    my $gnu = Chart::Gnuplot.new(:terminal("svg"), :filename("actual.svg"));
+    my @actual;
+    $gnu.multiplot(:writer(-> $msg { @actual.push($msg) }));
+    $gnu.dispose;
+    is @actual, ['set terminal svg', 'set output "actual.svg"', 'set multiplot'], 'multiplot without options configures output and does not append whitespace.';
+}
+
+{
+    my $gnu = Chart::Gnuplot.new(:terminal("svg"), :filename("actual.svg"));
+    my @actual;
+    my &writer = -> $msg { @actual.push($msg) };
+
+    $gnu.multiplot(:layout([1, 2]), :&writer, {
+        $gnu.plot(:function("sin(x)"), :&writer);
+        $gnu.plot(:function("cos(x)"), :&writer);
+    });
+    $gnu.plot(:function("tan(x)"), :&writer);
+    $gnu.dispose;
+
+    my @plot-commands = @actual.grep({ .starts-with("plot ") || .starts-with("replot ") });
+    is @plot-commands, ['plot sin(x)', 'plot cos(x)', 'plot tan(x)'], 'The block form renders panels and resets plotting state automatically.';
+    is @actual.grep(* eq 'unset multiplot').elems, 1, 'The block form ends multiplot exactly once.';
+}
+
+{
+    my $gnu = Chart::Gnuplot.new(:terminal("svg"), :filename("actual.svg"));
+    my @actual;
+    my &writer = -> $msg { @actual.push($msg) };
+
+    throws-like {
+        $gnu.multiplot(:layout([1, 1]), :&writer, {
+            die "plot failed";
+        });
+    }, X::AdHoc, message => 'plot failed', 'The block form propagates exceptions.';
+    is @actual[*-1], 'unset multiplot', 'The block form ends multiplot when its body throws.';
+    $gnu.dispose;
 }
 
 done-testing;


### PR DESCRIPTION
- Treats each panel as an independent `plot` or `splot` instead of using `replot`.
- Configures the terminal and output before entering multiplot mode.
- Tracks the multiplot lifecycle and resets plotting state when it ends.
- Adds a scoped block form that automatically exits multiplot mode, including when the block throws an exception.